### PR TITLE
Adding Slack Alerts if the Predefined mandatory tags are missing

### DIFF
--- a/source/resource-auto-tagger.py
+++ b/source/resource-auto-tagger.py
@@ -2,6 +2,8 @@ import json
 import logging
 import boto3
 import botocore
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
 
 logging.getLogger().setLevel(logging.INFO)
 log = logging.getLogger(__name__)
@@ -11,6 +13,8 @@ iam_client = boto3.client("iam")
 ec2_client = boto3.client("ec2")
 ec2_resource = boto3.resource("ec2")
 
+# Slack Client iInstantiation
+slack_client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
 
 def get_iam_role_tags(role_name):
     try:
@@ -32,6 +36,19 @@ def get_iam_user_tags(iam_user_name):
     except botocore.exceptions.ClientError as error:
         log.error(f"Boto3 API returned error: {error}")
         return None
+
+def send_slack_alerts(slack_alert_block, user_email):
+    channel_id = '@' + user_email.split('@')[0]
+    try:
+    # Call the conversations.list method using the WebClient
+        result = client.chat_postMessage(
+            channel=channel_id, blocks=slack_alert_block,
+            text="Important: Non-Compliant EC2 Instance")
+        log.info("'statusCode': 200")
+        log.info(f"'Slack Response': {result}")
+    except SlackApiError as error:
+        log.error(f"Slack API returned error: {error}")
+
 
 # Apply resource tags to EC2 instances & attached EBS volumes
 def set_ec2_instance_attached_vols_tags(ec2_instance_id, resource_tags):
@@ -107,9 +124,103 @@ def cloudtrail_event_parser(event):
 
     return returned_event_fields
 
+def get_iam_user_email_id(iam_user_name):
+    try:
+        response = iam_client.list_user_tags(UserName=iam_user_name)
+        iam_tag_list = response.get("Tags")
+        log.info(f"'IAM User Tag List': {iam_tag_list}")
+        for tag in iam_tag_list:
+            if tag['Key'] == 'Owner':
+                return tag['Value']
+    except botocore.exceptions.ClientError as error:
+        log.error(f"Boto3 API returned error: {error}")
+        return None
+
 
 def lambda_handler(event, context):
     resource_tags = []
+    user_email = False
+    mandatory_tags = ['Name', 'Department', 'Project'] 
+    instance_name = "Not Specified"
+    ec2_instance_id = ''
+    ec2_instance_name_block = "*EC2 Name:*\n" + instance_name
+    project_tag_allowed_values = "*Project   : * DAI, HAIC, HAMC, Aquarium, POCPuddle, EnterprisePuddle, SnowflakePuddle, SparklingWater, Steam, MLOps, H2O3, H2OAutoML \n \n "
+    department_tag_allowed_values = "*Department   : * Engineering, DataScience, ProductManagement, CustomerSuccess, SalesEngineering, SpecialOps \n \n"
+    name_tag_allowed_values = "*Name   :* Meaningful name to identify resource"
+    mandory_tag_allowed_values = {'Project': project_tag_allowed_values, 'Department' : department_tag_allowed_values, 'Name':  name_tag_allowed_values}
+    missing_mandatory_tag_allowed_values="*Missing Mandatory Tag keys and Allowed Values* \n \n "
+    instance_manage_tag_url="https://console.aws.amazon.com/ec2/v2/home?region=" + aws_region + "#ManageInstanceTags:instanceId=" + ec2_instance_id
+    owner_tag_filter=[{'Name': 'tag:Owner','Values': ['*']},{'Name': 'resource-id','Values': [ec2_instance_id]}]
+    instance_id_filter=[{'Name': 'resource-id','Values': [ec2_instance_id]}]
+    slack_alert_block = [
+    		{
+    			"type": "header",
+    			"text": {
+    				"type": "plain_text",
+    				"text": ":alert: Insufficient Tag Alert!"
+    			}
+    		},
+    		{
+    			"type": "context",
+    			"elements": [
+    				{
+    					"type": "plain_text",
+    					"text": "The EC2 You just created does not have mandotory tags configured."
+    				}
+    			]
+    		},
+    		{
+    			"type": "section",
+    			"text": {
+    				"type": "mrkdwn",
+    				"text": "<https://h2oai.atlassian.net/wiki/spaces/DEVOPS/pages/3620929755/H2O.AI+AWS+Account+Handling+User+Guidelines#Rules-and-Best-Practices|Please follow this guide when creating new AWS Resources>"
+    			}
+    		},
+    		{
+    			"type": "divider"
+    		},
+    		{
+    			"type": "section",
+    			"fields": [
+    				{
+    					"type": "mrkdwn",
+    					"text": ec2_instance_name_block
+    				}
+    			]
+    		},
+    		{
+    			"type": "divider"
+    		},
+    		{
+    			"type": "section",
+    			"text": {
+    				"type": "mrkdwn",
+    				"text": missing_mandatory_tag_allowed_values
+    			}
+    		},
+    		{
+    			"type": "divider"
+    		},
+    		{
+    			"type": "section",
+    			"text": {
+    				"type": "mrkdwn",
+    				"text": "Add missing tags "
+    			},
+    			"accessory": {
+    				"type": "button",
+    				"text": {
+    					"type": "plain_text",
+    					"text": "AWS Console EC2 Link"
+    				},
+    				"value": "click_me_123",
+    				"style": "primary",
+    				"url": instance_manage_tag_url,
+    				"action_id": "button-action"
+    			}
+    		}
+    	]
+
     # Parse the passed CloudTrail event and extract pertinent EC2 launch fields
     event_fields = cloudtrail_event_parser(event)
 
@@ -121,6 +232,7 @@ def lambda_handler(event, context):
         iam_user_resource_tags = get_iam_user_tags(event_fields["iam_user_name"])
         if iam_user_resource_tags:
             resource_tags += iam_user_resource_tags
+
 
     # Check for event date & time in returned CloudTrail event field
     # and append as resource tag
@@ -145,22 +257,39 @@ def lambda_handler(event, context):
     if event_fields.get("instances_set"):
         for item in event_fields.get("instances_set").get("items"):
             ec2_instance_id = item.get("instanceId")
-            Filter=[{'Name': 'tag:Owner','Values': ['*']},{'Name': 'resource-id','Values': [ec2_instance_id]}]
-            if ec2_client.describe_tags( Filters = Filter )['Tags']:
-                log.info("'statusCode': 500")
-                log.info(f"'Owner tag already Exists in Resource ID': {ec2_instance_id}")
-            else:
-                if set_ec2_instance_attached_vols_tags(ec2_instance_id, resource_tags):
-                    log.info(f"'Tags List': {resource_tags}")
-                    log.info("'statusCode': 200")
-                    log.info(f"'Resource ID': {ec2_instance_id}")
-                    log.info(f"'body': {json.dumps(resource_tags)}")
-
+            for tag in ec2_client.describe_tags( Filters = instance_id_filter )['Tags']:
+                if tag['Key'] == "Name":
+                    slack_alert_block[4]['fields'][0]['text'] = "*EC2 Name:*\n" + tag['Value']
+                if tag['Key'] in mandatory_tags:
+                    mandatory_tags.remove(tag['Key'])  
+                if tag['Key'] == 'Owner':
+                    if tag['Value'].split('@') == 'h2o.ai':
+                        user_email = tag['Value']
+                        log.infot(f"'IAM User's Email ID' :{user_email}")
+            log.info("'statusCode': 500")
+            log.info(f"'Owner tag already Exists in Resource ID': {ec2_instance_id}")
+                # Checking for other mandatory tags  
+            if mandatory_tags:
+                for missing_tag in mandatory_tags:
+                    missing_mandatory_tag_allowed_values += mandory_tag_allowed_values[missing_tag]
+                slack_alert_block[6]['text']['text'] = missing_mandatory_tag_allowed_values
+                if user_email:
+                    send_slack_alerts(slack_alert_block, user_email)
                 else:
-                    log.info("'statusCode': 500")
-                    log.info(f"'No tags applied to Resource ID': {ec2_instance_id}")
-                    log.info(f"'Lambda function name': {context.function_name}")
-                    log.info(f"'Lambda function version': {context.function_version}")
+                    if set_ec2_instance_attached_vols_tags(ec2_instance_id, resource_tags):
+                        log.info(f"'Tags List': {resource_tags}")
+                        log.info("'statusCode': 200")
+                        log.info(f"'Resource ID': {ec2_instance_id}")
+                        log.info(f"'body': {json.dumps(resource_tags)}")
+                        user_email=get_iam_user_email_id(event_fields["iam_user_name"])
+                        if user_email:
+                            send_slack_alerts(slack_alert_block, user_email)
+                            log.info(f"'IAM User's Email ID from IAM Tags': {user_email}")
+                    else:
+                        log.info("'statusCode': 500")
+                        log.info(f"'No tags applied to Resource ID': {ec2_instance_id}")
+                        log.info(f"'Lambda function name': {context.function_name}")
+                        log.info(f"'Lambda function version': {context.function_version}")
     else:
         log.info("'statusCode': 200")
         log.info(f"'No Amazon EC2 resources to tag': 'Event ID: {event.get('id')}'")


### PR DESCRIPTION
We need to make sure the users define "Name", "Department" "Project" tags. If at least one of them is missing a Slack alert must be sent to the resource creator.